### PR TITLE
slight change to protect from some crashes in `detect_markers`

### DIFF
--- a/aniposelib/boards.py
+++ b/aniposelib/boards.py
@@ -614,8 +614,13 @@ class CharucoBoard(CalibrationObject):
         params.adaptiveThreshWinSizeStep = 50
         params.adaptiveThreshConstant = 0
 
-        corners, ids, rejectedImgPoints = aruco.detectMarkers(
-            gray, self.dictionary, parameters=params)
+        try:
+            corners, ids, rejectedImgPoints = aruco.detectMarkers(
+                gray, self.dictionary, parameters=params) 
+        except Exception:
+            print('Exception raised from `aruco.detectMarkers()` in anipose\'s `boards.py`')
+            ids = None
+
 
         if ids is None:
             return [], []

--- a/aniposelib/boards.py
+++ b/aniposelib/boards.py
@@ -618,7 +618,6 @@ class CharucoBoard(CalibrationObject):
             corners, ids, rejectedImgPoints = aruco.detectMarkers(
                 gray, self.dictionary, parameters=params) 
         except Exception:
-            print('Exception raised from `aruco.detectMarkers()` in anipose\'s `boards.py`')
             ids = None
 
 


### PR DESCRIPTION
In some (rare-ish?) cases - such as when a charuco board is partially occluded - this line would cause an error that would cause the whole calibration to fail. 

I simply wrap that line in a `try`/`except` block and set `ids` to `None` if an exception occurs. The code downstream of this treats this frame like any other where a board was not detected