### PR TITLE
Replace numpy's matrix inverse with scipy's

### DIFF
--- a/aniposelib/cameras.py
+++ b/aniposelib/cameras.py
@@ -2,6 +2,7 @@ import cv2
 import numpy as np
 from copy import copy
 from scipy.sparse import lil_matrix, dok_matrix
+from scipy.linalg import inv
 from scipy import optimize
 from scipy import signal
 from numba import jit
@@ -962,7 +963,7 @@ class CameraGroup:
                     M_cam = self.cameras[cam_id].get_extrinsics_mat()
                     M_board_cam = make_M(rvecs_all[cam_id, point_id],
                                          tvecs_all[cam_id, point_id])
-                    M_board = np.matmul(np.linalg.inv(M_cam), M_board_cam)
+                    M_board = np.matmul(inv(M_cam), M_board_cam)
                     rvec, tvec = get_rtvec(M_board)
                     rvecs[board_num] = rvec
                     tvecs[board_num] = tvec

--- a/aniposelib/utils.py
+++ b/aniposelib/utils.py
@@ -2,6 +2,7 @@ import cv2
 import numpy as np
 from scipy.cluster.hierarchy import linkage, fcluster
 from scipy.cluster.vq import whiten
+from scipy.linalg import inv
 from collections import defaultdict, Counter
 import queue
 import pandas as pd
@@ -69,7 +70,7 @@ def get_transform(rtvecs, left, right):
         if good[left] and good[right]:
             M_left = make_M(d[left, 0:3], d[left, 3:6])
             M_right = make_M(d[right, 0:3], d[right, 3:6])
-            M = np.matmul(M_left, np.linalg.inv(M_right))
+            M = np.matmul(M_left, inv(M_right))
             L.append(M)
     L_best = select_matrices(L)
     M_mean = mean_transform(L_best)


### PR DESCRIPTION
Aniposelib's calibration function was failing with segfault errors on some machines when being called from a GUI (specifically when calibrating cameras in Freemocap on an arm Mac). I was able to track down the issue to numpy's linear algebra inverse function. I was able to circumvent the problem by replacing numpy's `np.linalg.inv` function with scipy's `scipy.linalg.inv` function.

Scipy's version of the function is a drop in replacement for numpy's, but has an additional check for finite numbers intended to reduce crashes and non termination. I suspect this is why it solves the problem. 

https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.inv.html