### PR TITLE
Add min_corners_intrinsic parameter to calibrate_rows and calibrate_videos methods

### DIFF
--- a/aniposelib/cameras.py
+++ b/aniposelib/cameras.py
@@ -1591,6 +1591,7 @@ class CameraGroup:
 
     def calibrate_rows(self, all_rows, board,
                        init_intrinsics=True, init_extrinsics=True, verbose=True,
+                       min_corners_intrinsic=9,
                        **kwargs):
         assert len(all_rows) == len(self.cameras), \
             "Number of camera detections does not match number of cameras"
@@ -1603,7 +1604,7 @@ class CameraGroup:
 
             if init_intrinsics:
                 objp, imgp = board.get_all_calibration_points(rows)
-                mixed = [(o, i) for (o, i) in zip(objp, imgp) if len(o) >= 9]
+                mixed = [(o, i) for (o, i) in zip(objp, imgp) if len(o) >= min_corners_intrinsic]
                 objp, imgp = zip(*mixed)
                 matrix = cv2.initCameraMatrix2D(objp, imgp, tuple(size))
                 camera.set_camera_matrix(matrix.copy())
@@ -1664,6 +1665,7 @@ class CameraGroup:
 
     def calibrate_videos(self, videos, board,
                          init_intrinsics=True, init_extrinsics=True, verbose=True,
+                         min_corners_intrinsic=9,
                          **kwargs):
         """Takes as input a list of list of video filenames, one list of each camera.
         Also takes a board which specifies what should be detected in the videos"""
@@ -1675,7 +1677,9 @@ class CameraGroup:
         error = self.calibrate_rows(all_rows, board,
                                     init_intrinsics=init_intrinsics,
                                     init_extrinsics=init_extrinsics,
-                                    verbose=verbose, **kwargs)
+                                    verbose=verbose,
+                                    min_corners_intrinsic=min_corners_intrinsic,
+                                    **kwargs)
         return error, all_rows
 
     def get_dicts(self):


### PR DESCRIPTION
## Description: 
Allows users to configure the minimum number of detected corners required for intrinsic camera matrix initialization. Previously this was hard-coded to 9. The parameter defaults to 9 to maintain backward compatibility.

## Motivation
Raising this parameter above 9 allowed me to successfully and accurately calibrate a camera array that otherwise failed due to some cameras not initiating their intrinsics. With the default value of 9, I observed this error:
```
Could not build calibration graph.                                                                                                                                                                                   
  Some group of cameras could not be paired by simultaneous calibration board detections.                                                                                                                              
  Check which cameras have different group numbers below to see the missing edges.
```
I tried to re-record my calibration video, but always some of the cameras could not be paired. It turned out these isolated cameras were being initialized with NaN values for their intrinsic parameters (i.e., cv2.initCameraMatrix2D() was returning NaN values). I tried reducing the threshold from 9 to 6, and the problem got even worse, with most cameras now returning NaN intrinsics. I then raised the threshold from 9 to 12, and the calibration finished without error. Bundle adjustment error and average per-frame reprojection error were both <1 pixel. I then tested with the threshold set to 33, and finally 54. Error rose only negligibly (still <1 pixel), and intrinsics and extrinsics (after re-orientation to a common coordinate frame) changed minimally. 

### Camera Array Details
- 7 synchronized WhiteMatter e3Vision cameras
- regular hexagon arrangement with 1 camera in the center
- adjacent cameras have overlapping FOV, but antipodal cameras do not

### Calibration Video Collection Procedure
All cameras were set to record at 10fps in MJPG mode and started simultaneously. A calibration board (800mm x 600mm coarse-pattern Charuco board from calib.io, 9x12 grid with 60mm checker width, 45mm marker width) was moved through the recording volume (a cylinder approximately 2m in diameter, 1m in height) at various angles for approximatly 7 minutes. Because the FOVs of antipodal cameras do not overlap, each camera experiences periods where the calibration board nearly or completely exits the FOV. 


## Additional Notes
Over the course of figuring out this solution, I ended up creating a variety of visualization, error estimation, and coordinate system re-orientation functionalities that may be of interest for aniposelib or anipose. It can be found here: https://github.com/tlancaster6/BigTankCalib