### PR TITLE
Upstream changes from cheese3d including GPU acceleration

### DIFF
--- a/aniposelib/boards.py
+++ b/aniposelib/boards.py
@@ -3,7 +3,9 @@ import numpy as np
 from abc import ABC, abstractmethod
 from tqdm import trange
 from collections import defaultdict
-
+import warnings
+warnings.filterwarnings("default", category=DeprecationWarning,
+                                   module="aniposelib.boards")
 
 def get_video_params_cap(cap):
     params = dict()
@@ -146,7 +148,7 @@ def extract_points(merged,
                     else:
                         row[cname]['rvec'] = np.full(3, np.nan, dtype='float64')
                         row[cname]['tvec'] = np.full(3, np.nan, dtype='float64')
-                
+
                 imgp[cix, rix] = filled
 
                 rvecs[cix, rix, ~bad] = row[cname]['rvec'].ravel()
@@ -539,6 +541,21 @@ class CharucoBoard(CalibrationObject):
         self.marker_length = marker_length
         self.manually_verify = manually_verify
 
+        # import aruco only here so that we only require opencv-contrib-python when using ChArUco module
+        global aruco
+        from cv2 import aruco
+
+        # OpenCV changed the aruco API in version 4.7
+        if hasattr(aruco, 'CharucoDetector'):
+            self.USE_OPEN_CV_47_API = True
+        else:
+            msg = (f"Your installed version of OpenCV is {cv2.__version__}\n" +
+                f"OpenCV changed the aruco API in version 4.7\n" +
+                f"Aniposelib will fall back to the old version of the API\n" +
+                f"but this support will be removed in the future.\n\n")
+            warnings.warn(msg, DeprecationWarning)
+            self.USE_OPEN_CV_47_API = False
+
         ARUCO_DICTS = {
             (4, 50): cv2.aruco.DICT_4X4_50,
             (5, 50): cv2.aruco.DICT_5X5_50,
@@ -559,11 +576,15 @@ class CharucoBoard(CalibrationObject):
         }
 
         dkey = (marker_bits, dict_size)
-        self.dictionary = cv2.aruco.getPredefinedDictionary(ARUCO_DICTS[dkey])
-
-        self.board = cv2.aruco.CharucoBoard([squaresX, squaresY],
-                                            square_length, marker_length,
-                                            self.dictionary)
+        self.dictionary = aruco.getPredefinedDictionary(ARUCO_DICTS[dkey])
+        if self.USE_OPEN_CV_47_API:
+            self.board = aruco.CharucoBoard(size=(squaresX, squaresY),
+                                            squareLength=square_length,
+                                            markerLength=marker_length,
+                                            dictionary=self.dictionary)
+            self.detector = aruco.CharucoDetector(self.board)
+        else:
+            self.board = aruco.CharucoBoard_create(squaresX, squaresY, square_length, marker_length, self.dictionary)
 
         total_size = (squaresX - 1) * (squaresY - 1)
 
@@ -587,7 +608,10 @@ class CharucoBoard(CalibrationObject):
         return np.copy(self.empty_detection)
 
     def draw(self, size):
-        return self.board.draw(size)
+        if self.USE_OPEN_CV_47_API:
+            return self.board.generateImage(size)
+        else:
+            return self.board.draw(size)
 
     def fill_points(self, corners, ids):
         out = self.get_empty_detection()
@@ -604,19 +628,21 @@ class CharucoBoard(CalibrationObject):
         else:
             gray = image
 
-        params = cv2.aruco.DetectorParameters()
-        params.cornerRefinementMethod = cv2.aruco.CORNER_REFINE_CONTOUR
-        params.adaptiveThreshWinSizeMin = 50
+        if self.USE_OPEN_CV_47_API:
+            params = aruco.DetectorParameters()
+        else:
+            params = aruco.DetectorParameters_create()
+        params.cornerRefinementMethod = aruco.CORNER_REFINE_CONTOUR
+        params.adaptiveThreshWinSizeMin = 100
         params.adaptiveThreshWinSizeMax = 700
         params.adaptiveThreshWinSizeStep = 50
         params.adaptiveThreshConstant = 0
 
         try:
-            corners, ids, rejectedImgPoints = cv2.aruco.detectMarkers(
-                gray, self.dictionary, parameters=params) 
+            corners, ids, rejectedImgPoints = aruco.detectMarkers(
+                gray, self.dictionary, parameters=params)
         except Exception:
             ids = None
-
 
         if ids is None:
             return [], []
@@ -629,7 +655,7 @@ class CharucoBoard(CalibrationObject):
 
         if refine:
             detectedCorners, detectedIds, rejectedCorners, recoveredIdxs = \
-                cv2.aruco.refineDetectedMarkers(gray, self.board, corners, ids,
+                aruco.refineDetectedMarkers(gray, self.board, corners, ids,
                                             rejectedImgPoints,
                                             K, D,
                                             parameters=params)
@@ -645,14 +671,19 @@ class CharucoBoard(CalibrationObject):
         else:
             gray = image
 
-        corners, ids = self.detect_markers(image, camera, refine=True)
-        if len(corners) > 0:
-            ret, detectedCorners, detectedIds = cv2.aruco.interpolateCornersCharuco(
-                corners, ids, gray, self.board)
-            if detectedIds is None:
+        if self.USE_OPEN_CV_47_API:
+            detectedCorners, detectedIds, _, _ = self.detector.detectBoard(gray)
+            if detectedCorners is None:
                 detectedCorners = detectedIds = np.float64([])
         else:
-            detectedCorners = detectedIds = np.float64([])
+            corners, ids = self.detect_markers(image, camera, refine=True)
+            if len(corners) > 0:
+                ret, detectedCorners, detectedIds = aruco.interpolateCornersCharuco(
+                    corners, ids, gray, self.board)
+                if detectedIds is None:
+                    detectedCorners = detectedIds = np.float64([])
+            else:
+                detectedCorners = detectedIds = np.float64([])
 
         if len(detectedCorners) > 0 \
             and self.manually_verify \

--- a/aniposelib/boards.py
+++ b/aniposelib/boards.py
@@ -613,7 +613,7 @@ class CharucoBoard(CalibrationObject):
             out[i] = cxs
         return out
 
-    def detect_markers(self, image):
+    def detect_markers(self, image, camera=None, refine=True):
         if len(image.shape) == 3:
             gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         else:

--- a/aniposelib/cameras.py
+++ b/aniposelib/cameras.py
@@ -501,10 +501,13 @@ class CameraGroup:
             points = points.reshape(-1, 1, 2)
             one_point = True
 
-        # Determine batch size and prepare for batching
-        N = points.shape[1]
-        batch_size = min(100000, N)
-        num_batches = (N + batch_size - 1) // batch_size
+        if undistort:
+            new_points = np.empty(points.shape)
+            for cnum, cam in enumerate(self.cameras):
+                # must copy in order to satisfy opencv underneath
+                sub = np.copy(points[cnum])
+                new_points[cnum] = cam.undistort_points(sub)
+            points = new_points
 
         n_cams, n_points, _ = points.shape
 

--- a/aniposelib/cameras.py
+++ b/aniposelib/cameras.py
@@ -546,8 +546,9 @@ class CameraGroup:
             good = ~jnp.isnan(points[:, :, 0])
             is_good = jnp.expand_dims(jnp.sum(good, axis=0) >= 2, axis=-1)
             # batch and parallelize triangulation
-            points = jnp.reshape(points, (-1, points.shape[0], 100000, points.shape[-1]))
-            good = jnp.reshape(good, (-1, good.shape[0], 100000))
+            batch_size = min(100000, points.shape[1])
+            points = jnp.reshape(points, (-1, points.shape[0], batch_size, points.shape[-1]))
+            good = jnp.reshape(good, (-1, good.shape[0], batch_size))
             vtriangulate = jax.vmap(triangulate_simple, in_axes=(1, None, 1))
             def scan_vtriangulate(carry, args):
                 points, good = args

--- a/aniposelib/cameras.py
+++ b/aniposelib/cameras.py
@@ -1,3 +1,4 @@
+import os
 import cv2
 import numpy as np
 from copy import copy
@@ -12,8 +13,6 @@ import itertools
 from tqdm import trange
 from pprint import pprint
 import time
-import jax
-import jax.numpy as jnp
 
 from .boards import merge_rows, extract_points, \
     extract_rtvecs, get_video_params
@@ -21,13 +20,17 @@ from .utils import get_initial_extrinsics, make_M, get_rtvec, \
     get_connections
 
 def build_triangulate_syseq(point, camera_mat):
+    import jax.numpy as jnp
+
     eqs = jnp.expand_dims(point, axis=-1) * jnp.expand_dims(camera_mat[2], axis=0)
     eqs = eqs - camera_mat[0:2]
 
     return eqs
 
-@jax.jit
 def triangulate_simple(points, camera_mats, valid):
+    import jax
+    import jax.numpy as jnp
+
     A = jax.vmap(build_triangulate_syseq)(points, camera_mats)
     A = jnp.where(jnp.expand_dims(valid, axis=(1, 2)), A, 0)
     A = jnp.reshape(A, (-1, 4))
@@ -486,9 +489,14 @@ class CameraGroup:
 
         return out
 
-    def triangulate(self, points, undistort=True, progress=False, fast=False):
+    def triangulate(self, points, undistort=True, progress=False, fast=False, disable_64bit=False):
         """Given an CxNx2 array, this returns an Nx3 array of points,
         where N is the number of points and C is the number of cameras"""
+        import jax
+        import jax.numpy as jnp
+
+        if (not disable_64bit) and (os.getenv("ANIPOSE_DISABLE_JAX_X64", "0").lower() in ("0", "no", "false")):
+            jax.config.update("jax_enable_x64", True)
 
         assert points.shape[0] == len(self.cameras), \
             "Invalid points shape, first dim should be equal to" \
@@ -537,7 +545,7 @@ class CameraGroup:
             out = np.full((n_points, 3), np.nan)
 
             # Get vectorized triangulate function
-            vtriangulate = jax.vmap(triangulate_simple, in_axes=(1, None, 1))
+            vtriangulate = jax.vmap(jax.jit(triangulate_simple), in_axes=(1, None, 1))
 
             # Process in batches
             for batch_idx in range(num_batches):

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ setuptools.setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Image Recognition"
     ],
-    dependency_links=[
-        'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
-    ],
     install_requires=[
         'opencv-contrib-python>=4.7.0.68',
         'numba', 'pandas',

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,14 @@ setuptools.setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Image Recognition"
     ],
+    dependency_links=[
+        'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
+    ],
     install_requires=[
         'opencv-contrib-python>=4.7.0.68',
         'numba', 'pandas',
-        'numpy', 'scipy', 'toml', 'tqdm'
+        'numpy', 'scipy', 'toml', 'tqdm',
+        'jax[cuda11_pip]'
     ],
     extras_require={
     }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         'opencv-contrib-python>=4.7.0.68',
         'numba', 'pandas',
         'numpy', 'scipy', 'toml', 'tqdm',
-        'jax[cuda11_pip]'
+        'jax'
     ],
     extras_require={
     }


### PR DESCRIPTION
Hi @lambdaloop apologies for the delay, but as previously discussed, this PR should upstream changes made to aniposelib as part of developing cheese3d. The two major sources of changes are:
- adding Jax as a dependency and updating initial triangulation to use it for acceleration (GPU, falls back to CPU when unavailable)
- updating calibration to support OpenCV 4.7+ APIs (the current main branch uses the latest package version but potentially deprecated APIs)

~~Possibly this needs a rebase before it can be merged, but I am opening the PR to help guide that process.~~ Rebasing complete.